### PR TITLE
Made dictation concurrent with token generation

### DIFF
--- a/llm/application/voicechat.cc
+++ b/llm/application/voicechat.cc
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
                 std::getline(std::cin, input);
                 input = "A chat between a human and an assistant.\n\n### Human: " + input + "\n### Assistant: \n";
 
-                LLaMAGenerate(&model, LLaMA_FP32, input, generation_config, "models/llama_vocab.bin", true, true);
+                LLaMAGenerate(m_path, &model, LLaMA_FP32, input, generation_config, "models/llama_vocab.bin", true, true);
             }
         } else if (format_id == INT4) {
             m_path = "INT4/" + m_path;
@@ -127,22 +127,16 @@ int main(int argc, char* argv[]) {
                 std::string input;
                 std::string output;
                 std::string model_input;
+
                 std::system("./application/sts_utils/listen");
                 std::ifstream in("tmpfile");
                 std::getline(in, input);
                 std::system("rm tmpfile");
+
                 std::cout << input << std::endl;
                 model_input = "A chat between a human and an assistant.\n\n### Human: " + input + "\n### Assistant: \n";
-                output = LLaMAGenerate(&model, LLaMA_INT4, model_input, generation_config, "models/llama_vocab.bin",
+                LLaMAGenerate(m_path, &model, LLaMA_INT4, model_input, generation_config, "models/llama_vocab.bin",
                                        true, true);
-                // Remove newlines
-                output.erase(std::remove(output.begin(), output.end(), '\n'), output.end());
-                // Remove quotes
-                output.erase(std::remove(output.begin(), output.end(), '\"'), output.end());
-                // Remove hashtags
-                output.erase(std::remove(output.begin(), output.end(), '#'), output.end());
-                output = "./application/sts_utils/speak \"" + output + "\"";
-                std::system(output.c_str());
             }
         } else {
             std::cout << std::endl;

--- a/llm/src/nn_modules/non_cuda/LLaMAGenerate.cc
+++ b/llm/src/nn_modules/non_cuda/LLaMAGenerate.cc
@@ -3,6 +3,16 @@
 #include "LLaMATokenizer.h"
 #include "common.h"
 #include "utils.h"
+#include <thread>
+#include <string>
+#include <sstream>
+
+
+// Function to speak in the background
+void sayInBackground(const std::string& text) {
+    std::string command = "./application/sts_utils/speak \"" + text + "\"";
+    std::system(command.c_str());
+}
 
 std::string LLaMAGenerate(std::string param_path, void *model_ptr, int model_type, std::string text, const struct opt_params generation_config,
                           std::string voc_path, bool interactive, bool voicechat) {
@@ -167,11 +177,59 @@ std::string LLaMAGenerate(std::string param_path, void *model_ptr, int model_typ
         input_ids = std::vector<int>{id};
 
         if (interactive && !skip) {
-            std::cout << llama_id_to_token(vocab, id) << std::flush;
             output += llama_id_to_token(vocab, id);
-        }
+            std::cout << llama_id_to_token(vocab, id) << std::flush;
+            if (voicechat) {
+                // Remove quotes
+                output.erase(std::remove(output.begin(), output.end(), '\"'), output.end());
+                // Remove hashtags
+                output.erase(std::remove(output.begin(), output.end(), '#'), output.end());
+                // Remove dashes
+                std::replace(output.begin(), output.end(), '-', ' ');
 
+                size_t lastPos;
+                // starts ealier but slows down dictation
+                bool ended = false;
+                if (output.find(", ") != std::string::npos){
+                    lastPos = output.rfind(',');
+                    ended = true;
+                }
+                if (output.find("\n") != std::string::npos){
+                    lastPos = output.rfind('\n');
+                    ended = true;
+                }
+                else if (output.find(". ") != std::string::npos){
+                    lastPos = output.rfind('.');
+                    ended = true;
+                }
+                else if (output.find("! ") != std::string::npos){
+                    lastPos = output.rfind('!');
+                    ended = true;
+                }
+                else if (output.find("? ") != std::string::npos){
+                    lastPos = output.rfind('?');
+                    ended = true;
+    
+                }
+                else if (output.find(": ") != std::string::npos){
+                    lastPos = output.rfind(':');
+                    ended = true;
+                }
+                if (ended){
+                    // Extract sentence 1 (up to and including the last period)
+                    std::string output_copy = output.substr(0, lastPos + 1);
+                    // Extract beginning of sentence 2 (excluding the space after the last period)
+                    output = output.substr(lastPos + 1); // Skip the last period and space
+                    std::thread sayThread(sayInBackground, output_copy);
+                    sayThread.detach(); 
+                } 
+            } 
+        }
         --n_remain;
+    }
+    if (voicechat && interactive){
+        std::thread sayThread(sayInBackground, output);
+        sayThread.detach();
     }
 
     if (interactive) std::cout << std::endl;

--- a/llm/src/nn_modules/non_cuda/LLaMAGenerate.cc
+++ b/llm/src/nn_modules/non_cuda/LLaMAGenerate.cc
@@ -11,7 +11,8 @@
 // Function to speak in the background
 void sayInBackground(const std::string& text) {
     std::string command = "./application/sts_utils/speak \"" + text + "\"";
-    std::system(command.c_str());
+    int result = std::system(command.c_str());
+    (void)result;
 }
 
 std::string LLaMAGenerate(std::string param_path, void *model_ptr, int model_type, std::string text, const struct opt_params generation_config,


### PR DESCRIPTION
## Description

Dictation of the voice chat will no longer wait for the model to finish generating a response but instead will be concurrent to token generation. This is done by using multithreading and separating the output into phrases separated by delimiters such as punctuation.

## Changes Made

- updated voicechat.cc to accommodate changes made in previous commits.
- changed the generate function to only store phrases of the output instead of the whole response, and to dictate the phrase as soon as it is done generating.
- Uses ", ", "\n", ". ", "! ", "?", ": " as delimiters
- Used multithreading so that generation would not be interrupted by dictation.

## Video
https://www.youtube.com/watch?v=mv2y9HRS1mE&feature=youtu.be

## Checklist

Please review and check off these items before submitting your pull request:

- [x] I have tested the changes locally, and they work as expected.

## Reviewers

@RaymondWang0 



